### PR TITLE
manifest: fix dependencies, add build verification action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Samples
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize West
+        run: |
+          west init -l .
+          west update --narrow -o=--depth=1
+          west zephyr-export
+
+      - name: Install Dependencies
+        run: |
+          pip install -r zephyr/scripts/requirements.txt
+
+      - name: Build and Test
+        run: |
+          west twister -T app/ -T test/ --integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Use ci-base image and install only the required toolchain to save disk
+    # space
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:latest
+      image: ghcr.io/zephyrproject-rtos/ci-base:latest
 
     steps:
       - name: Checkout
@@ -26,7 +28,13 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install -r zephyr/scripts/requirements.txt
+          pip install -r ../zephyr/scripts/requirements.txt
+
+      - name: Setup SDK
+        # Install only the ARM toolchain to minimize download size and disk
+        # usage
+        run: |
+          west sdk install --toolchains arm-zephyr-eabi
 
       - name: Build and Test
         run: |

--- a/west.yml
+++ b/west.yml
@@ -9,13 +9,14 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v3.7.1
+      revision: main
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.
         name-allowlist:
           #- lvgl      # Uncomment to include LittlevGL for the git bisect demo
           - cmsis      # required by the ARM port
+          - cmsis_6
           - mbedtls
           - hal_nordic
           - hal_stm32


### PR DESCRIPTION
- Fix the cmsis_6 dependency
- Update to latest Zephyr upstream version (main)
- add a github build action that validates the build using twister test runner.