### PR TITLE
slides: add topics that have been removed for the EW25 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Resources to quickly get started with Zephyr:
 
 ## Documentation and Slides 📖
 
-The workshop includes both a web-based documentation (Sphinx) and a slide presentation (Slidev). The slides are integrated into the documentation.
+The workshop includes both a web-based documentation (Sphinx) and a slide
+presentation (Slidev). The slides are integrated into the documentation.
 
 ### Building the Documentation
 
-The documentation is located in the `doc` folder. To build the full documentation including the integrated slides, use `tox`:
+The documentation is located in the `doc` folder. To build the full
+documentation including the integrated slides, use `tox`:
 
 ```shell
 cd doc
@@ -32,28 +34,42 @@ tox -e html
 tox -e docs
 ```
 
-The output will be available in `doc/_build/html/index.html`. 
+The output will be available in `doc/_build/html/index.html`.
 
 > [!NOTE]
-> Slidev uses ES Modules and cannot be opened directly via the `file://` protocol. You must serve the documentation via a web server (e.g., using `tox -e docs` for local preview).
+> Slidev uses ES Modules and cannot be opened directly via the `file://`
+> protocol. You must serve the documentation via a web server
+> (e.g., using `tox -e docs` for local preview).
 
 ### Slides 📊
 
-The presentation slides are located in `doc/slides` and are written with [Slidev](https://sli.dev/). They are automatically built and included when building the documentation, but they can also be built standalone:
+The presentation slides are located in `doc/slides` and are written with
+[Slidev](https://sli.dev/). They are automatically built and included when
+building the documentation, but they can also be built standalone:
 
 ```shell
 cd doc
 tox -e slides
 ```
 
-The standalone build output is located in `doc/slides_dist/zephyr-workshop_slides`.
+The standalone build output is located in
+`doc/slides_dist/zephyr-workshop_slides`.
+
+#### Live Preview (Development)
+For the best experience when editing slides, use the Slidev development server which provides instant hot-reloading:
+
+```shell
+cd doc/slides
+npm install
+npm run dev
+```
 
 ### Presentation License
 
-The content in the `doc/slides` directory is licensed under the Creative Commons
-Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). A full copy of
-the license text is available in the `LICENSE_PRESENTATION` file at the root of
-this repository.
+The content in the `doc/slides` directory is licensed under the Creative
+Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). A full
+copy of the license text is available in the `LICENSE_PRESENTATION` file at the
+root of this repository.
 
 ## Firmware 🛠
 
@@ -71,20 +87,7 @@ Zephyr's Zbus. The application is located at ´app´, related tests are in the
 ´tests´ folder.
 
 The application should run on most supported boards as it only uses a button
-and an led. However, if you do not have a hardware available, you can run the
-application with Renode. The Renode configuration is located in the `utils`
-folder. For running the application in Renode, you have to build for the
-`stm32f4_disco` board.
-
-You can build the application as follows:
-```shell
-west build -b stm32f4_disco app -p
-```
-
-And run in Renode:
-```shell
-renode util/stm32f4.resc --disable-gui --console
-```
+and an led.
 
 To run and explore integration tests with twister, you can build the tests and
 application for mulitple boards:

--- a/doc/slides/pages/01-introduction.md
+++ b/doc/slides/pages/01-introduction.md
@@ -15,6 +15,38 @@ level: 1
 - **Experience:** RTOS (FreeRTOS, Zephyr), NXP MCUX, hardware development
 
 ---
+
+## Workshop Goals
+
+<div class="grid grid-cols-2 gap-4">
+
+<div>
+
+- Combine theory with hands-on practice
+- Introduction to Zephyr RTOS
+- Setting up the SDK
+  - On a Local Machine
+  - GitHub Codespaces
+- Exploring key features
+- Hands-on development
+
+</div>
+
+<div class="flex flex-col items-center justify-center">
+  <img src="/images/zephyr_logo.png" class="h-40" />
+</div>
+
+</div>
+
+---
+
+## Audience Check
+
+- What are your goals for the Workshop?
+- Have you used an RTOS before?
+- Your experience with Zephyr?
+
+---
 ---
 
 ## Areas of Work
@@ -48,9 +80,10 @@ level: 1
 
 - Governed by the Linux Foundation
 - Vendor-neutrality: fairness and interoperability
-- Technical Steering Committee (TSC) and Working Groups (WG) make technical decisions
+- Technical Steering Committee (TSC) and Working Groups (WG)
 - Security and tooling (e.g. SBOM) as integral part
-- Safety certification ongoing
+- **Alternative to vendor SDKs**
+- **Safety certification ongoing**
 
 </div>
 

--- a/doc/slides/pages/02-development-setup.md
+++ b/doc/slides/pages/02-development-setup.md
@@ -148,6 +148,17 @@ GitHub Codespaces<sup>1</sup>
 
 ---
 
+## Recommendations from Experience
+
+Virtual Machines in combination with embedded hardware can bring their own problems.
+
+**Prioritize a local environment over a cloud environment**
+- Hardware is better accessible
+- Better integration of your own tools
+- Check vendor tools that can enhance your Zephyr Dev Environment
+
+---
+
 ## Hands-on 1 - Codespaces Setup
 
 <div class="grid grid-cols-2 gap-4">

--- a/doc/slides/pages/05-application-development.md
+++ b/doc/slides/pages/05-application-development.md
@@ -63,6 +63,166 @@ level: 1
 </div>
 
 ---
+
+## Modular Development
+
+<div class="grid grid-cols-2 gap-4">
+
+<div>
+
+- **General:** Code reuse, maintainability, readability
+- **IPC:** Communication e.g. via Zbus
+- **Context:** Each module can be controlled independently
+- **Testing:** Modules can be tested separately
+
+</div>
+
+<div>
+
+```text
+app/
+├── CMakeLists.txt
+├── Kconfig
+├── prj.conf
+└── src
+    ├── common
+    │   ├── CMakeLists.txt
+    │   ├── message_channel.c
+    │   └── message_channel.h
+    ├── main.c
+    └── modules
+        ├── button
+        │   ├── button.c
+        │   ├── CMakeLists.txt
+        │   └── Kconfig.button
+        └── led
+            ├── led.c
+            ├── CMakeLists.txt
+            └── Kconfig.led
+```
+
+</div>
+
+</div>
+
+---
+
+## Testing Modules
+
+<div class="grid grid-cols-2 gap-4">
+
+<div>
+
+**Isolated testing of modules**
+- Add subsystems like `shell`, `ztest` for test cases
+- Tests reference modules via CMake
+- Interfaces abstracted via Zbus
+
+**Example Test Structure:**
+```text
+test/
+├── button
+│   ├── CMakeLists.txt
+│   ├── prj.conf
+│   └── src/main.c
+└── led
+    ├── CMakeLists.txt
+    └── src/main.c
+```
+
+</div>
+
+<div>
+
+```cmake
+# test/button/CMakeLists.txt
+target_sources(app PRIVATE src/main.c)
+add_subdirectory(../../app/src/common common)
+add_subdirectory(../../app/src/modules/button button)
+```
+
+```c
+// test/button/src/main.c
+void button_test_msg_cb(const struct zbus_channel *chan) {
+    const enum sys_msg *msg = zbus_chan_const_msg(chan);
+    if (*msg == SYS_BUTTON_PRESSED) {
+        LOG_INF("Button pressed!");
+    }
+}
+ZBUS_LISTENER_DEFINE(button_test, button_test_msg_cb);
+ZBUS_CHAN_ADD_OBS(button_ch, button_test, 1);
+```
+
+</div>
+
+</div>
+
+---
+
+## Automated Testing with Twister
+
+<div class="grid grid-cols-2 gap-4">
+
+<div>
+
+**Zephyr Test Runner (Twister)**
+- `west twister` - Automates building and running tests
+- Supports multiple platforms (real HW or simulation)
+- Integration tests via `sample.yaml`
+
+**Run Integration Tests:**
+```shell
+west twister -T app/ -T test/ --integration
+```
+
+</div>
+
+<div>
+
+**Example `sample.yaml`:**
+```yaml
+integration_platforms:
+  - reel_board
+  - frdm_k64f
+  - nrf52840dk/nrf52840
+```
+
+**Output:**
+```text
+INFO - Total complete: 24/24 100%
+INFO - 24 of 24 configurations passed
+INFO - Run completed
+```
+
+</div>
+
+</div>
+
+---
+
+## Hands-on 4: Extend the Application
+
+<div class="grid grid-cols-2 gap-4">
+
+<div>
+
+Currently: **standby**, **sleep**.
+**Task:** Add a third state: **active**.
+Cycle via button: `standby` -> `sleep` -> `active`
+
+- **Sleep:** LED off
+- **Standby:** LED blinking
+- **Active:** LED on
+
+</div>
+
+<div class="flex flex-col items-center justify-center">
+  <img src="/images/zbus_application.svg" class="h-60" />
+</div>
+
+</div>
+
+---
 ---
 
 ## Hands-on 5: BLE Sensor Improvements

--- a/doc/slides/pages/07-backup-slides.md
+++ b/doc/slides/pages/07-backup-slides.md
@@ -55,37 +55,7 @@ Date:   Thu Jan 25 11:09:06 2024 +0100
 layout: default
 ---
 
-## Renode: Technical Overview
-
-<div class="grid grid-cols-2 gap-4">
-
-<div>
-<v-clicks>
-
-- Testing of embedded systems in a reproducible virtual environment
-- Simulation of unmodified binaries for target hardware
-- Simulates entire SoCs, including CPUs, peripherals, and interconnects
-
-</v-clicks>
-</div>
-
-<div>
-<v-clicks>
-
-- Enables complex network simulations, both wired and wireless
-- Allows for interactive debugging, system state inspection, and automated testing
-- Open Source, actively developed by Antmicro
-
-</v-clicks>
-</div>
-
-</div>
-
----
-layout: default
----
-
-## Hands-On 4: Extension to 3 States - test
+## Hands-On 4: Extension to 3 States - Solution (Test)
 
 ```diff
 test/led/src/main.c


### PR DESCRIPTION
Add these topics to the slides. In some time I will add a mechanism to selectively build a slide-deck consisting of only chosen topics. This will make it easy to tailor the workshop for different audiences.