### PR TITLE
infrastructure: migrate to native_sim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ _build
 doc/slides_dist/
 *.pygtex
 *.pygstyle
+.venv
+
+# Open Code Agents file
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ west update
 # e.g. for reel_board
 west build -b reel_board samples/01_hello_world -p
 
-# Or for a simulation that can run on the host system
-west build -b qemu_cortex_m0 samples/01_hello_world -p
+# Or for native execution on the host system
+west build -b native_sim samples/01_hello_world -p
 ```
 
 Once the sample is build, run the following command to flash/run it:
@@ -148,6 +148,6 @@ Once the sample is build, run the following command to flash/run it:
 # on a board
 west flash
 
-# qemu simulation
+# native_sim execution
 west build -t run
 ```

--- a/README.md
+++ b/README.md
@@ -151,3 +151,30 @@ west flash
 # native_sim execution
 west build -t run
 ```
+
+### Building and Running the Application on native_sim
+
+The application can be built and run on `native_sim` for testing without hw:
+
+```shell
+# Build the application
+west build -b native_sim app -p
+
+# Run with shell on separate UART (creates predictable symlink)
+./build/zephyr/zephyr.exe -uart_1_attach_uart_cmd='ln -sf %s /tmp/zephyr_shell'
+```
+
+This creates two separate consoles:
+- **Logs** - Appear in the terminal output (uart0)
+- **Shell** - Accessible via `/tmp/zephyr_shell` symlink (uart1)
+
+Interact with the shell:
+
+```shell
+# Send commands to the application
+echo "my_app button button_press" > /tmp/zephyr_shell
+echo "help" > /tmp/zephyr_shell
+
+# Or use screen for interactive session
+tio /tmp/zephyr_shell
+```

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,3 +7,8 @@ target_sources(app PRIVATE src/main.c)
 add_subdirectory(src/common common)
 add_subdirectory(src/modules/led led)
 add_subdirectory(src/modules/button button)
+
+# Button mock for native_sim (simulates GPIO button presses)
+if(CONFIG_BOARD_NATIVE_SIM)
+  add_subdirectory(src/modules/button_mock button_mock)
+endif()

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -2,6 +2,7 @@ menu "Application"
 
 rsource "src/modules/led/Kconfig.led"
 rsource "src/modules/button/Kconfig.button"
+rsource "src/modules/button_mock/Kconfig.button_mock"
 
 endmenu
 

--- a/app/boards/native_sim.overlay
+++ b/app/boards/native_sim.overlay
@@ -1,0 +1,29 @@
+/**
+ * Native Sim Overlay for Application
+ *
+ * This overlay adds a button (sw0) alias for the native_sim board
+ * to enable the button module to compile and run.
+ * Also enables uart1 for shell on separate console.
+ */
+
+/ {
+	aliases {
+		sw0 = &button0;
+	};
+
+	chosen {
+		zephyr,shell-uart = &uart1;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			label = "User button";
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -10,3 +10,11 @@ CONFIG_ZBUS=y
 
 # Shell Testing
 CONFIG_SHELL=y
+CONFIG_SHELL_BACKEND_SERIAL=y
+CONFIG_SHELL_PROMPT_UART="uart:~$ "
+
+# Disable shell log backend to keep logs only on console UART
+CONFIG_SHELL_LOG_BACKEND=n
+
+# GPIO Support
+CONFIG_GPIO=y

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -4,14 +4,15 @@ sample:
 common:
   tags: introduction
   integration_platforms:
+    - native_sim
     - reel_board
-    - frdm_k64f
-    - nucleo_wb55rg
-    - nucleo_l496zg
-    - mimxrt1010_evk
-    - nucleo_l452re
-    - nrf5340dk/nrf5340/cpuapp
-    - stm32f4_disco
+    #- frdm_k64f
+    #- nucleo_wb55rg
+    #- nucleo_l496zg
+    #- mimxrt1010_evk
+    #- nucleo_l452re
+    #- nrf5340dk/nrf5340/cpuapp
+    #- stm32f4_disco
     # The following platforms are not supported in twister currently
     #- nrf52833dk_nrf52833
     #- atsamr21_xpro

--- a/app/src/modules/button_mock/CMakeLists.txt
+++ b/app/src/modules/button_mock/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Jonas Remmert
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(app PRIVATE button_mock.c)

--- a/app/src/modules/button_mock/Kconfig.button_mock
+++ b/app/src/modules/button_mock/Kconfig.button_mock
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Jonas Remmert
+# SPDX-License-Identifier: Apache-2.0
+
+config BUTTON_MOCK
+	bool "Button mock module for native_sim"
+	depends on BOARD_NATIVE_SIM
+	default y
+	help
+	  Enable button mock module that simulates physical button presses
+	  using the GPIO emulator for native_sim builds.
+
+module = BUTTON_MOCK
+module-str = button_mock
+source "subsys/logging/Kconfig.template.log_config"

--- a/app/src/modules/button_mock/button_mock.c
+++ b/app/src/modules/button_mock/button_mock.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Jonas Remmert
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_emul.h>
+#include <zephyr/shell/shell.h>
+
+LOG_MODULE_REGISTER(button_mock, LOG_LEVEL_DBG);
+
+#define BUTTON_NODE DT_ALIAS(sw0)
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(BUTTON_NODE, gpios);
+
+static struct k_work_delayable button_press_work;
+static struct k_work_delayable button_release_work;
+
+static void button_release_work_handler(struct k_work *work)
+{
+	gpio_emul_input_set_dt(&button, 0);
+	LOG_INF("Button released");
+}
+
+static void button_press_work_handler(struct k_work *work)
+{
+	gpio_emul_input_set_dt(&button, 1);
+	LOG_INF("Button pressed (mock)");
+	
+	/* Schedule button release after 100ms */
+	k_work_schedule(&button_release_work, K_MSEC(100));
+}
+
+/* Shell command to trigger button press */
+static int cmd_mock_button(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+	
+	LOG_INF("Triggering mock button press");
+	k_work_schedule(&button_press_work, K_NO_WAIT);
+	
+	return 0;
+}
+
+SHELL_CMD_REGISTER(mock_button, NULL, "Simulate button press via GPIO", cmd_mock_button);
+
+static int button_mock_init(void)
+{
+	LOG_INF("Button mock module initialized");
+	
+	k_work_init_delayable(&button_press_work, button_press_work_handler);
+	k_work_init_delayable(&button_release_work, button_release_work_handler);
+	
+	return 0;
+}
+
+SYS_INIT(button_mock_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/app/src/modules/led/led.c
+++ b/app/src/modules/led/led.c
@@ -60,16 +60,16 @@ static void led_fn(void)
 		switch (sys_state) {
 		case SYS_SLEEP:
 			gpio_pin_set_dt(&led, 0);
-			printk("LED off\n");
+			LOG_DBG("LED off");
 			/* Nothing to do, blocking wait to save energy */
 			ret = zbus_sub_wait(&led_subscriber, &chan, K_FOREVER);
 			break;
 		case SYS_STANDBY:
 			gpio_pin_set_dt(&led, 1);
-			printk("LED on\n");
+			LOG_DBG("LED on");
 			k_sleep(K_MSEC(50));
 			gpio_pin_set_dt(&led, 0);
-			printk("LED off\n");
+			LOG_DBG("LED off");
 			k_sleep(K_MSEC(500));
 			/* Blinking led, blocking wait not possible */
 			ret = zbus_sub_wait(&led_subscriber, &chan, K_NO_WAIT);

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,3 +21,4 @@ Zephyr-Workshop
    :hidden:
 
    src/setup
+   src/application

--- a/doc/slides/pages/03-workspace-application.md
+++ b/doc/slides/pages/03-workspace-application.md
@@ -260,7 +260,7 @@ cirrus-logic  infineon    openisa     telink
 [..]
 
 zephyrproject/zephyr:~$ ls boards/
-96boards               firefly       qemu
+96boards               firefly       native_sim
 actinius               gd            rak
 ...
 ```

--- a/doc/slides/pages/04-code-examples.md
+++ b/doc/slides/pages/04-code-examples.md
@@ -43,8 +43,7 @@ level: 1
 **Build and run:**
 
 ```shell
-west build -b qemu_cortex_m0 \
-  samples/01_hello_world -p
+west build -b native_sim samples/01_hello_world -p
 west build -t run
 ```
 
@@ -115,7 +114,7 @@ int main(void)
 ## 01_hello_world Application Build Output
 
 ```shell
-west build -b qemu_cortex_m0 samples/01_hello_world/ -p
+west build -b native_sim samples/01_hello_world/ -p
 -- Found host-tools: zephyr 0.17.0 (/home/jonas/zephyr-sdk-0.17.0)
 -- Found toolchain: zephyr 0.17.0 (/home/jonas/zephyr-sdk-0.17.0)
 [..]
@@ -191,7 +190,7 @@ build/
 
 ```shell
 *** Booting Zephyr OS build v4.1.0 ***
-Hello World! qemu_cortex_m3/ti_lm3s6965
+Hello World! native_sim
 ```
 
 ---
@@ -251,7 +250,7 @@ int main(void)
 
 ```
 *** Booting Zephyr OS build v4.1.0 ***
-Hello World! qemu_cortex_m0
+Hello World! native_sim
 [00:00:00.001,691] <err> hello_world: error string
 [00:00:00.001,843] <dbg> hello_world: main: debug string
 [00:00:00.001,859] <inf> hello_world: info string
@@ -633,16 +632,14 @@ Indication complete
 Build and run the samples<sup>1</sup>:
 
 ```shell
-west build -b qemu_cortex_m0 \
-  samples/02_logging -p
+west build -b native_sim samples/02_logging -p
 west build -t run
 ```
 
 **or**
 
 ```shell
-west build -b reel_board@2 \
-  samples/02_logging -p
+west build -b reel_board@2 samples/02_logging -p
 west flash
 ```
 

--- a/doc/src/application.rst
+++ b/doc/src/application.rst
@@ -1,0 +1,105 @@
+.. Copyright (c) 2026 Jonas Remmert
+.. SPDX-License-Identifier: Apache-2.0
+
+Application
+===========
+
+The example application demonstrates a modular Zephyr design with inter-module communication via Zbus.
+
+Overview
+--------
+
+The application consists of three main modules:
+
+- **Button Module**: Handles physical button presses via GPIO interrupts
+- **LED Module**: Controls LED state based on system state
+- **Main Application**: Manages system state machine and coordinates modules
+
+System States
+-------------
+
+The application implements two system states:
+
+- **Sleep**: LED is off, system waits for events
+- **Standby**: LED blinks, system is active
+
+Button presses toggle between these states via Zbus messages.
+
+Running on native_sim
+---------------------
+
+The application can be built and tested on native_sim without hardware:
+
+.. code-block:: bash
+
+   # Build the application
+   west build -b native_sim app -p
+
+   # Run with shell on separate console
+   ./build/zephyr/zephyr.exe -uart_1_attach_uart_cmd='ln -sf %s /tmp/zephyr_shell'
+
+This creates two separate consoles:
+
+- **Logs** (/dev/pts/X) - Application logs and boot messages
+- **Shell** (/tmp/zephyr_shell) - Interactive shell for commands
+
+Shell Commands
+--------------
+
+Two methods are available to trigger button events:
+
+**1. GPIO Level (Hardware Simulation)**
+
+Uses the GPIO emulator to simulate physical button press:
+
+.. code-block:: bash
+
+   uart:~$ mock_button
+
+This triggers the actual GPIO interrupt handler with debouncing.
+
+**2. Application Level (Zbus)**
+
+Sends button event directly via Zbus:
+
+.. code-block:: bash
+
+   uart:~$ my_app button button_press
+
+This bypasses the GPIO layer and sends the event directly to the application.
+
+Architecture
+------------
+
+**Module Communication**
+
+Modules communicate via Zbus channels:
+
+- ``button_ch``: Button press events
+- ``led_ch``: LED state changes
+
+**Hardware Abstraction**
+
+On native_sim, the application uses:
+
+- **GPIO Emulator** (zephyr,gpio-emul) for button and LED
+- **PTY UART** for shell on separate console
+- **Devicetree Overlay** to define button alias and UART configuration
+
+The overlay file (``app/boards/native_sim.overlay``) defines:
+
+- ``sw0`` alias for the button
+- ``uart1`` enabled for shell
+- Shell UART mapped to ``zephyr,shell-uart``
+
+Module Structure
+----------------
+
+.. code-block:: text
+
+   app/src/modules/
+   ├── button/          # Physical button handling
+   ├── button_mock/     # GPIO emulator interface (native_sim only)
+   └── led/             # LED control
+
+The ``button_mock`` module provides the ``mock_button`` shell command and is only compiled for native_sim boards.

--- a/samples/01_hello_world/README.rst
+++ b/samples/01_hello_world/README.rst
@@ -12,16 +12,16 @@ prints "Hello World" to the console.
 Building and Running
 ********************
 
-This application can be built and executed on QEMU as follows:
+This application can be built and executed on native_sim as follows:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :host-os: unix
-   :board: qemu_x86
+   :board: native_sim
    :goals: run
    :compact:
 
-To build for another board, change "qemu_x86" above to that board's name.
+To build for another board, change "native_sim" above to that board's name.
 
 Sample Output
 =============
@@ -30,4 +30,4 @@ Sample Output
 
     Hello World! x86
 
-Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+Exit native_sim by pressing :kbd:`CTRL+C`.

--- a/samples/01_hello_world/sample.yaml
+++ b/samples/01_hello_world/sample.yaml
@@ -5,7 +5,7 @@ sample:
 common:
   tags: introduction
   integration_platforms:
-    - native_posix
+    - native_sim
     - reel_board
   harness: console
   harness_config:

--- a/samples/02_logging/sample.yaml
+++ b/samples/02_logging/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: logging test
 common:
   integration_platforms:
-    - native_posix
+    - native_sim
 tests:
   sample.basic.logging:
     build_only: true

--- a/samples/03_workqueues/sample.yaml
+++ b/samples/03_workqueues/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: workqueue test
 common:
   integration_platforms:
-    - native_posix
+    - native_sim
 tests:
   sample.basic.workqueue:
     build_only: true

--- a/samples/04_shell/sample.yaml
+++ b/samples/04_shell/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: console build test
 common:
   integration_platforms:
-    - native_posix
+    - native_sim
 tests:
   sample.basic.console:
     build_only: true

--- a/samples/05_sensor/sample.yaml
+++ b/samples/05_sensor/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: sensor test
 common:
   integration_platforms:
+    - native_sim
     - reel_board
 tests:
   sample.basic.sensor:

--- a/samples/06_ble/sample.yaml
+++ b/samples/06_ble/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: ble build test
 common:
   integration_platforms:
+    - native_sim
     - reel_board
 tests:
   sample.basic.ble:

--- a/samples/07_display_cfb/sample.yaml
+++ b/samples/07_display_cfb/sample.yaml
@@ -1,6 +1,8 @@
 common:
   harness: display
   tags: display
+  integration_platforms:
+    - native_sim
 sample:
   description: Character framebuffer test
   name: cfb sample

--- a/test/button/sample.yaml
+++ b/test/button/sample.yaml
@@ -4,6 +4,7 @@ sample:
 common:
   tags: introduction
   integration_platforms:
+    - native_sim
     - reel_board
     - frdm_k64f
     - nucleo_wb55rg

--- a/test/led/sample.yaml
+++ b/test/led/sample.yaml
@@ -4,6 +4,7 @@ sample:
 common:
   tags: introduction
   integration_platforms:
+    - native_sim
     - reel_board
     - frdm_k64f
     - nucleo_wb55rg


### PR DESCRIPTION
migrate with all tests and the application to `native_sim`.

This is very powerful as all code can now run natively on the developer machine. There are virtual com ports for a) logging and b) shell in parallel. That opens the door to unit testing and fast development cycles.