### PR TITLE
.github: add daily scheduled build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 8 * * *'  # Run daily at 8 AM UTC
+  workflow_dispatch:  # Allow manual trigger
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,4 @@ jobs:
 
       - name: Build and Test
         run: |
-          west twister -T test/ --integration
-          west twister -T app/ --integration
-          west twister -T samples/ --integration
+          west twister -T test -T app -T samples --integration


### PR DESCRIPTION
The workhsop uses the main branch of the zephyr project. This CI action will run daily to ensure the app, tests and all samples always remain functional.