### PR TITLE
ci: avoid duplicate Playwright browser downloads

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -61,12 +61,16 @@ jobs:
             xindy
 
       - name: Install dependencies
+        timeout-minutes: 10
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: |
           npm --prefix slides install --no-save --package-lock=false
           touch slides/node_modules/.installed
         working-directory: doc
 
       - name: Install Playwright browsers
+        timeout-minutes: 10
         run: |
           npm --prefix slides exec playwright install -- --with-deps chromium
         working-directory: doc

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -44,10 +44,16 @@ jobs:
             xindy
 
       - name: Install dependencies
-        run: npm --prefix slides install --package-lock=false
+        timeout-minutes: 10
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: |
+          npm --prefix slides install --no-save --package-lock=false
+          touch slides/node_modules/.installed
         working-directory: doc
 
       - name: Install Playwright browsers
+        timeout-minutes: 10
         run: npm --prefix slides exec playwright install -- --with-deps chromium
         working-directory: doc
 


### PR DESCRIPTION
Skip Playwright browser downloads during npm install and let the explicit Playwright install step handle Chromium setup.