### PR TITLE
ci: use Node LTS for Playwright install

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Install PDF build dependencies
         run: |
@@ -70,7 +70,7 @@ jobs:
         working-directory: doc
 
       - name: Install Playwright browsers
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           npm --prefix slides exec playwright install -- --with-deps chromium
         working-directory: doc

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Install PDF build dependencies
         run: |
@@ -53,7 +53,7 @@ jobs:
         working-directory: doc
 
       - name: Install Playwright browsers
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm --prefix slides exec playwright install -- --with-deps chromium
         working-directory: doc
 


### PR DESCRIPTION
Node 24 can hang after Playwright browser downloads complete. Use Node 22 LTS for docs workflows and allow more time for browser setup.